### PR TITLE
feat: 🎸 enable edge colors for different dataset response codes

### DIFF
--- a/react-d3/src/Graph.js
+++ b/react-d3/src/Graph.js
@@ -179,10 +179,21 @@ export default function Graph () {
       .attr('opacity', 0.5)
       .attr('fill', 'none')
       .attr('stroke', d =>
+             // This section is for CLAIM MATCHING data
+             d.original.label == 3 ? "red" :
+             d.original.label == 4 ? "blue" :
+             d.original.label == 5 ? "purple" :
+             d.original.label == 6 ? "green" :
+             d.original.label == 7 ? "orange" :
+             d.original.label == 8 ? "teal" :
+             d.original.label == 9 ? "black" :
+             // End of CLAIM MATCHING data
+             // start of section for claimbuster label data
              d.original.label == -1 ? "red" :
              d.original.label == -2 ? "purple" :
              d.original.label ==  1 ? "green" :
                "yellow" // zero here
+             // end of section for claimbuster label data
       )
           .attr('stroke-width', d => d.thickness);
     // source node rectangles


### PR DESCRIPTION
all lines were yellow as function for label to css color was made for claimbuster data, added section for claim matching based on stats(most frequent responses included), need to generalize this to arbitrary data in the api and send color codes back to state